### PR TITLE
fix: report pull request CI with required check name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions:
 
 jobs:
   verify:
-    name: Verify
+    name: CI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## What
- Rename the dedicated PR workflow job from `Verify` to `CI`.

## Why
This makes the separate PR workflow report the status check name expected by the ruleset, and the `fix:` commit will be picked up by release-please after merge.

## Testing
- bun run typecheck
- bun run lint
- bun test --concurrent src/
- bun run build
